### PR TITLE
Add tile json override URI

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.28.0"
   hashes = [
+    "h1:OsPtt0JGl70xbY2+V/ai0d+Jk2p7pvkW8h9IKhIr288=",
     "h1:TXCUuuaf2q54C43bxSNiF9g+cxTr8zqEZem0pW15cjE=",
     "zh:1d4806e50971d2cd565273cedf3206e38931677a6f546cf2b9fb140b52b80604",
     "zh:3f076791002b8afa5ba2d2038f1e1db5956022327eb5242152723ed410ae4571",

--- a/data.tf
+++ b/data.tf
@@ -25,8 +25,8 @@ data "aws_iam_policy_document" "bucket" {
       ]
     }
     resources = [
-      aws_s3_bucket.tile.arn,
-      "${aws_s3_bucket.tile.arn}/*"
+      local.bucket_arn,
+      "${local.bucket_arn}/*"
     ]
   }
   statement {
@@ -39,8 +39,8 @@ data "aws_iam_policy_document" "bucket" {
     }
     effect = "Deny"
     resources = [
-      aws_s3_bucket.tile.arn,
-      "${aws_s3_bucket.tile.arn}/*"
+      local.bucket_arn,
+      "${local.bucket_arn}/*"
     ]
     principals {
       type        = "*"

--- a/integrations.tf
+++ b/integrations.tf
@@ -1,7 +1,3 @@
-locals {
-  tile_json_uri = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
-}
-
 resource "aws_api_gateway_integration" "json_get" {
   rest_api_id             = aws_api_gateway_rest_api.tile.id
   resource_id             = aws_api_gateway_resource.tileset.id

--- a/integrations.tf
+++ b/integrations.tf
@@ -1,3 +1,7 @@
+locals {
+  tile_json_uri = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
+}
+
 resource "aws_api_gateway_integration" "json_get" {
   rest_api_id             = aws_api_gateway_rest_api.tile.id
   resource_id             = aws_api_gateway_resource.tileset.id
@@ -5,7 +9,7 @@ resource "aws_api_gateway_integration" "json_get" {
   type                    = "AWS"
   integration_http_method = "GET"
   credentials             = aws_iam_role.tile.arn
-  uri                     = "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
+  uri                     = local.tile_json_uri
   request_parameters = {
     "integration.request.path.tileset" = "method.request.path.tileset"
   }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,6 @@
+locals {
+    buckets_to_create = var.s3_skip_creation == true ? [] : [var.s3_bucket_name]
+    bucket_policy = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
+    bucket_arn = "arn:aws:s3:::${var.s3_bucket_name}"
+    tile_json_uri = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -3,5 +3,5 @@ locals {
   bucket_policy           = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
   bucket_arn              = "arn:aws:s3:::${var.s3_bucket_name}"
   tile_json_uri           = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
-  execution_role_policies = setunion(var.api_execution_role_policy_arns, ["arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"])
+  execution_role_policies = merge(var.api_execution_role_policy_arns, { AmazonAPIGatewayPushToCloudWatchLogs : "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs" })
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-    buckets_to_create = var.s3_skip_creation == true ? [] : [var.s3_bucket_name]
+    buckets_to_create = var.s3_skip_creation == true ? {} : { name: var.s3_bucket_name}
     bucket_policy = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
     bucket_arn = "arn:aws:s3:::${var.s3_bucket_name}"
     tile_json_uri = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-    buckets_to_create = var.s3_skip_creation == true ? {} : { name: var.s3_bucket_name}
-    bucket_policy = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
-    bucket_arn = "arn:aws:s3:::${var.s3_bucket_name}"
-    tile_json_uri = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
+  buckets_to_create = var.s3_skip_creation == true ? {} : { name : var.s3_bucket_name }
+  bucket_policy     = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
+  bucket_arn        = "arn:aws:s3:::${var.s3_bucket_name}"
+  tile_json_uri     = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  buckets_to_create = var.s3_skip_creation == true ? {} : { name : var.s3_bucket_name }
-  bucket_policy     = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
-  bucket_arn        = "arn:aws:s3:::${var.s3_bucket_name}"
-  tile_json_uri     = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
+  buckets_to_create       = var.s3_skip_creation == true ? {} : { name : var.s3_bucket_name }
+  bucket_policy           = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
+  bucket_arn              = "arn:aws:s3:::${var.s3_bucket_name}"
+  tile_json_uri           = var.tile_json_integration_override != "" ? var.tile_json_integration_override : "arn:aws:apigateway:${var.api_region}:s3:path/${var.s3_bucket_name}/{tileset}/tile.json"
+  execution_role_policies = setunion(var.api_execution_role_policy_arns, ["arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"])
 }

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,8 @@ resource "aws_api_gateway_rest_api" "tile" {
 }
 
 module "bucket" {
-  source = "./modules/s3"
-  for_each = local.buckets_to_create
-  s3_bucket_name = each.value.name
+  source           = "./modules/s3"
+  for_each         = local.buckets_to_create
+  s3_bucket_name   = each.value.name
   s3_bucket_policy = local.bucket_policy
 }

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,13 @@ resource "aws_iam_role" "tile" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
+resource "aws_iam_policy_attachment" "policies" {
+  for_each   = toset(local.execution_role_policies)
+  name       = each.key
+  roles      = [aws_iam_role.tile.name]
+  policy_arn = each.key
+}
+
 resource "aws_api_gateway_rest_api" "tile" {
   name               = var.api_name
   description        = "Tile service"

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@ resource "aws_iam_role" "tile" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-resource "aws_iam_policy_attachment" "policies" {
-  for_each   = toset(local.execution_role_policies)
+resource "aws_iam_policy_attachment" "tile_role_policies" {
+  for_each   = local.execution_role_policies
   name       = each.key
   roles      = [aws_iam_role.tile.name]
-  policy_arn = each.key
+  policy_arn = each.value
 }
 
 resource "aws_api_gateway_rest_api" "tile" {

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,6 @@ resource "aws_api_gateway_rest_api" "tile" {
 module "bucket" {
   source = "./modules/s3"
   for_each = local.buckets_to_create
-  s3_bucket_name = each.value
+  s3_bucket_name = each.value.name
   s3_bucket_policy = local.bucket_policy
 }

--- a/main.tf
+++ b/main.tf
@@ -3,48 +3,15 @@ resource "aws_iam_role" "tile" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-resource "aws_s3_bucket" "tile" {
-  bucket = var.s3_bucket_name
-}
-
-resource "aws_s3_bucket_policy" "tile" {
-  bucket = aws_s3_bucket.tile.id
-  policy = var.s3_bucket_policy != "" ? var.s3_bucket_policy : data.aws_iam_policy_document.bucket.json
-}
-
-resource "aws_s3_bucket_acl" "tile" {
-  bucket = aws_s3_bucket.tile.bucket
-  acl    = "private"
-}
-
-resource "aws_s3_bucket_cors_configuration" "tile" {
-  bucket = aws_s3_bucket.tile.bucket
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["GET"]
-    allowed_origins = ["null"]
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "tile" {
-  bucket = aws_s3_bucket.tile.bucket
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "tile" {
-  bucket                  = aws_s3_bucket.tile.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
 resource "aws_api_gateway_rest_api" "tile" {
   name               = var.api_name
   description        = "Tile service"
   binary_media_types = var.api_binary_media_types
+}
+
+module "bucket" {
+  source = "./modules/s3"
+  for_each = local.buckets_to_create
+  s3_bucket_name = each.value
+  s3_bucket_policy = local.bucket_policy
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,0 +1,39 @@
+resource "aws_s3_bucket" "tile" {
+  bucket = var.s3_bucket_name
+}
+
+resource "aws_s3_bucket_policy" "tile" {
+  bucket = aws_s3_bucket.tile.id
+  policy = var.s3_bucket_policy
+}
+
+resource "aws_s3_bucket_acl" "tile" {
+  bucket = aws_s3_bucket.tile.bucket
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_cors_configuration" "tile" {
+  bucket = aws_s3_bucket.tile.bucket
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = ["null"]
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tile" {
+  bucket = aws_s3_bucket.tile.bucket
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tile" {
+  bucket                  = aws_s3_bucket.tile.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -1,0 +1,9 @@
+variable "s3_bucket_name" {
+  description = "Name of S3 bucket where tiles will be stored."
+  type        = string
+}
+
+variable "s3_bucket_policy" {
+  description = "A customised policy for the S3 bucket to support advanced use cases."
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -86,9 +86,9 @@ variable "api_throttling_rate_limit" {
 }
 
 variable "api_execution_role_policy_arns" {
-  description = "ARNs of additional policies to be attached to the API execution role."
-  default     = []
-  type        = list
+  description = "Names and ARNs of additional policies to be attached to the API execution role."
+  default     = {}
+  type        = map(any)
 }
 
 variable "s3_bucket_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,13 @@ variable "api_throttling_rate_limit" {
 }
 
 variable "s3_bucket_policy" {
-  description = "A customised policy for the S3 bucket to support advanced use cases"
+  description = "A customised policy for the S3 bucket to support advanced use cases."
+  default     = ""
+  type        = string
+}
+
+variable "tile_json_integration_override" {
+  description = "Optional override for the TileJson integration URI."
   default     = ""
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,12 @@ variable "s3_bucket_policy" {
   type        = string
 }
 
+variable "s3_skip_creation" {
+  description = "Optional override to skip creation of the S3 bucket and policies. Useful for when the bucket is created outside of Terraform."
+  default     = false
+  type        = bool
+}
+
 variable "tile_json_integration_override" {
   description = "Optional override for the TileJson integration URI."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,12 @@ variable "api_throttling_rate_limit" {
   type        = number
 }
 
+variable "api_execution_role_policy_arns" {
+  description = "ARNs of additional policies to be attached to the API execution role."
+  default     = []
+  type        = list
+}
+
 variable "s3_bucket_policy" {
   description = "A customised policy for the S3 bucket to support advanced use cases."
   default     = ""


### PR DESCRIPTION
Addresscloud has a use-case where we need to use an alternative S3 location for the TileJSON files. This change adds support for an override variable that modifies the API GW integration. Note that this change is just for TileJSON, and not the tiles themselves.